### PR TITLE
CMake: Bump required version to 3.12 (needed by blah)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.6)
+cmake_minimum_required(VERSION 3.12)
 project(TinyLink)
 
 # C++ version

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ I intend to add more documentation and clarify some of the code and assets over 
  - [stream archive](https://twitch.tv/noelfb)
  
 ### building
-  - You need C++17 and CMake
+  - You need C++17 and CMake 3.12+
   - Make sure you have SDL2 headers & libraries, and make sure CMake can find them
   - All the art was made in [Aseprite](https://www.aseprite.org/). To modify or add new sprites, you'll need to use aseprite.
 


### PR DESCRIPTION
Follow-up to https://github.com/NoelFB/blah/pull/6 (updated submodule to latest `master`).