### PR TITLE
clang not valid constexp -> update blah lib to latest master

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .vscode
 out
 CMakeSettings.json
+build/*

--- a/src/game.cpp
+++ b/src/game.cpp
@@ -347,8 +347,8 @@ void Game::render()
 		{
 			auto w = Content::font.width_of(ending);
 			auto pos = Point(room.x * width + width / 2, room.y * height + 20);
-			batch.str(Content::font, ending, pos + Point(0, 1), TextAlign::Top, 8, Color::black);
-			batch.str(Content::font, ending, pos, TextAlign::Top, 8, Color::white);
+			batch.str(Content::font, ending, pos + Point(0, 1), Vec2f(0.0, 0.0), 8, Color::black);
+			batch.str(Content::font, ending, pos, Vec2f(0.0, 0.0), 8, Color::white);
 		}
 
 		// end camera offset


### PR DESCRIPTION
Tried to compile but Clang complained about this not being a valid `constexp`

```
		constexp bool is_little_endian() { return (*((short*)"AB") != 0x4243); }
```

I realised that this was already fixed in 'blah' so I updated the library and fixed minor breaking changes