### PR TITLE
Use Vec2f for orb's diff

### DIFF
--- a/src/components/orb.cpp
+++ b/src/components/orb.cpp
@@ -22,7 +22,7 @@ Point Orb::target() const
 void Orb::update()
 {
 	auto mover = get<Mover>();
-	auto diff = Vec2(target() - entity()->position).normal();
+	auto diff = Vec2f(target() - entity()->position).normal();
 	mover->speed = diff * speed;
 }
 


### PR DESCRIPTION
At the moment the diff uses `Vec2i` so `normal()` will always return `(0, 0)`. This will cause the `mover->speed` to always be zero.

Looks like something changed when `Blah` was updated.

[video of orb not moving](https://user-images.githubusercontent.com/42767280/219958267-7ca7686c-fc49-4e1c-9c82-179daaba8607.webm)
